### PR TITLE
Fix error when /usr/local/include is in system includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         -Wno-c++98-compat-pedantic
         -Wno-padded
         -Wno-switch-enum
-
+        -Wno-poison-system-directories
         -fcolor-diagnostics
     )
 elseif(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
Added -Wno-poison-system-directories since this will prevent building on machines, such as macos with brew, that use /usr/local/include.  -Weverything enables it now.